### PR TITLE
Initialize design docs for top-level decisions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,8 @@
+pull_request_rules:
+  - name: Automatic merge design doc changes on approval
+    conditions:
+      - "files=^docs\\/design-docs\\/.*\\.md$"
+      - "#approved-reviews-by>=1"
+    actions:
+      merge:
+        method: merge

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Global owners
+*                               @tianhaoz95
+
+# Documentation content owners
+README.md                       @tianhaoz95 @ninjatron
+docs/README.md                  @tianhaoz95 @ninjatron
+docs/design-docs/*.md           @tianhaoz95 @ninjatron
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# acumany-re
+# Acumany Re
+
+<!--
+  @todo Rename the product
+  @body Come up with a name that is better than Acumany before launch.
+-->
+
 Building a world where all experiences are valued.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,45 @@
+# Overview
+
+## UI/UX
+
+For now, UI/UX is going through a brainstorm session, see [here](design-docs/ui-ux-study).
+
+## Tech stack
+
+For now, the tech stack is going through a brainstorm session, see [here](design-docs/tech-stack-study).
+
+<!--
+  @todo Add details for tech stack
+  @body After the tech stack is decided, add details here for new developers to get started.
+-->
+
+# Getting started
+
+## App
+
+<!--
+  @todo Add getting started guide
+  @body After the tech stack infra is done, add instructions for new developers to get started.
+-->
+
+## Docs
+
+### Public
+
+#### Overview
+
+For simplicity, we use [Docsify](https://docsify.js.org/) as the documentation tool for public information.
+
+#### View docs
+
+To view the docs online, check <http://tianhaoz.com/acumany-re> for the content on the `master` branch.
+
+To view the docs in local repository, follow the [instructions](https://docsify.js.org/#/quickstart?id=quick-start) to install Docsify, and then run the command `docsify serve docs` in the repository root directory.
+
+#### Modify docs
+
+To modify the docs, simply create/remove/modify the `README` files in the `docs` directory and open a pull request to check in the code (no further actions are needed).
+
+### Confidential
+
+Confidential information is documented in the Wiki of the private repository, [`acumany-re-credential`](https://github.com/tianhaoz95/acumany-re-credential).

--- a/docs/design-docs/tech-stack-study.md
+++ b/docs/design-docs/tech-stack-study.md
@@ -1,0 +1,38 @@
+# Tech Stack Study
+
+This design doc is the initial feasibility study to help decide the tech stack that we should use to build the app.
+
+## Platform preference
+
+<!--
+  @todo Platform preference
+  @body Decide if we should go with mobile first or web first.
+-->
+
+## Service vendor
+
+<!--
+  @todo Choose service vendor
+  @body List our needs and avaiable frameworks, and choose the one that fits our needs.
+-->
+
+## App framework
+
+<!--
+  @todo Choose app framework
+  @body List our needs and avaiable frameworks, and choose the one that fits our needs.
+-->
+
+## Server framework
+
+<!--
+  @todo Choose server framework
+  @body List our needs and avaiable frameworks, and choose the one that fits our needs.
+-->
+
+## App server interface schema
+
+<!--
+  @todo Choose app server interface schema
+  @body List our needs and avaiable app server interface schema, and choose the one that fits our needs.
+-->

--- a/docs/design-docs/ui-ux-study.md
+++ b/docs/design-docs/ui-ux-study.md
@@ -1,0 +1,6 @@
+# UI/UX Study
+
+<!--
+  @todo Add mockups
+  @body Add a few mockups to guide the design of technical stack
+-->

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'Acumany Re',
+      repo: 'https://github.com/tianhaoz95/acumany-re',
+      relativePath: true,
+    }
+  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a barebone skeleton of **Tech stack** and **UI/UX** design docs along with several TODOs to populate the design docs.

This is to have a record of the design choices to guide development.

Also, this pull request adds `CODEOWNER` for better code management and automatic pull request merging for design docs.