### PR TITLE
chore: add release drafter CI actions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.TIANHAOZ_GITHUB_TOKEN }}


### PR DESCRIPTION
Since the release drafter app is being deprecated, this commit will switch to use GitHub actions to draft releases like described in https://github.com/release-drafter/release-drafter.