### PR TITLE
fix: replace the invalid name

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.TIANHAOZ_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TIANHAOZ_TOKEN_FOR_GITHUB_ACTIONS }}


### PR DESCRIPTION
Turns out that anything containing GITHUB_TOKEN substr is not valid for secret ID, so I will need to change this to something else.