### PR TITLE
fix(infra): remove automatic approval from Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,12 +8,3 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-
-  - name: Automatic approve design doc changes for tianhaoz95
-    conditions:
-      - author=tianhaoz95
-      - -files~=^(!?docs/design-doc/)
-    actions:
-      review:
-        type: APPROVE
-        message: Hi tianhaoz95! Since you are the owner of the repository, your changes in design docs is automatically approved!


### PR DESCRIPTION
Since Mergify doesn't have write access to the repository, the approval is essentially useless for protected branches. ( close #49 )